### PR TITLE
Сross platform networking support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ development purposes only and not recommended for production use.
 
 # Quick Start
 
+For Linux machines:
 ``` sh
 $ git clone https://github.com/nspcc-dev/neofs-aio.git /opt/neofs
 $ cd /opt/neofs
@@ -21,6 +22,14 @@ $ docker-compose up -d
 ```
 
 All the services will be listening on `localhost` interface by default.
+
+For Windows and macOS use `docker-compose.cross.yml` without `host` network mode.
+``` sh
+$ git clone https://github.com/nspcc-dev/neofs-aio.git /opt/neofs
+$ cd /opt/neofs
+$ docker-compose -f docker-compose.cross.yml up -d
+```
+
 On the first start you have to run (this command will allow you to create containers):
 ``` sh
 $ make prepare.ir

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ development purposes only and not recommended for production use.
 # Server requirements
 
 - Docker with docker-compose
+- `expect` 
+- `jq`
+- `curl`
 
 # Quick Start
 

--- a/docker-compose.cross.yml
+++ b/docker-compose.cross.yml
@@ -1,0 +1,121 @@
+---
+
+version: "2.4"
+services:
+  morph:
+    image: nspccdev/neo-go:${NEOGO_VERSION}
+    container_name: morph
+    domainname: neofs
+    hostname: morph
+    restart: always
+    stop_signal: SIGKILL
+    environment:
+      - ACC=/config/morph_chain.gz
+    volumes:
+      - ./vendor/morph_chain.gz:/config/morph_chain.gz
+      - ./morph/protocol.privnet.yml:/config/protocol.privnet.yml
+      - ./morph/node-wallet.json:/config/node-wallet.json
+    ports:
+      - "30333:30333" # RPC
+    healthcheck:
+      test: ["CMD-SHELL", "neo-go query committee -r http://127.0.0.1:30333 | grep 02b3622bf4017bdfe317c58aed5f4c753f206b7db896046fa7d774bbc4bf7f8dc2"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+      start_period: 10s
+
+  ir:
+    image: nspccdev/neofs-aio:${AIO_VERSION}
+    container_name: ir
+    domainname: neofs
+    hostname: ir
+    restart: on-failure
+    stop_signal: SIGKILL
+    environment:
+      - NEOFS_IR_MORPH_ENDPOINT_CLIENT=http://morph:30333
+      - NEOFS_IR_MORPH_ENDPOINT_NOTIFICATION=ws://morph:30333/ws
+    volumes:
+      - ./morph/node-wallet.json:/config/node-wallet.json
+      - ./ir/wallet.key:/config/wallet.key
+      - ./ir/config.yaml:/config/config.yaml
+      - ./vendor/locode_db:/config/locode.db
+    entrypoint: /bin/neofs-ir
+    command: --config /config/config.yaml
+    healthcheck:
+      test: ["CMD-SHELL", "/bin/neofs-cli control healthcheck --ir --endpoint localhost:16512 --wallet /config/wallet.key | grep 'Health status: READY'"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+      start_period: 20s
+    depends_on:
+      morph:
+        condition: service_healthy
+
+  sn:
+    image: nspccdev/neofs-aio:${AIO_VERSION}
+    domainname: neofs
+    hostname: sn
+    container_name: sn
+    restart: on-failure
+    stop_signal: SIGKILL
+    environment:
+      - NEOFS_MORPH_RPC_ENDPOINT=http://morph:30333
+      - NEOFS_MORPH_NOTIFICATION_ENDPOINT=ws://morph:30333/ws
+      - NEOFS_NODE_ADDRESSES=grpc://sn:8080
+      - NEOFS_GRPC_0_ENDPOINT=:8080
+      - NEOFS_CONTROL_GRPC_ENDPOINT=:16513
+    volumes:
+      - ./sn/wallet.key:/config/wallet-sn.key
+      - ./sn/config.yaml:/config/config.yaml
+      - data:/data
+    ports:
+      - "8080:8080"   # NeoFS API RPC
+      - "16513:16513" # Control service
+    entrypoint: /bin/neofs-node
+    command: --config /config/config.yaml
+    healthcheck:
+      test: ["CMD-SHELL", "/bin/neofs-cli control healthcheck --endpoint localhost:16513 --wallet /config/wallet-sn.key | grep 'Health status: READY'"]
+      interval: 2s
+      timeout: 1s
+      retries: 5
+      start_period: 10s
+    depends_on:
+      ir:
+        condition: service_healthy
+
+  http_gw:
+    image: nspccdev/neofs-http-gw:${HTTPGW_VERSION}
+    domainname: neofs
+    hostname: http_gw
+    container_name: http_gw
+    restart: on-failure
+    stop_signal: SIGKILL
+    env_file: [ "./http/http.env" ]
+    environment:
+      - HTTP_GW_LISTEN_ADDRESS=:8081
+      - HTTP_GW_PEERS_0_ADDRESS=sn:8080
+    volumes:
+      - ./http/node-wallet.json:/config/wallet.json
+    ports:
+      - "8081:8081" # HTTP Gateway endpoint
+    depends_on:
+      - sn
+
+  nginx_gw:
+    image: nginx:stable-alpine
+    domainname: neofs
+    hostname: nginx_gw
+    container_name: nginx_gw
+    restart: on-failure
+    stop_signal: SIGKILL
+    volumes:
+      - ./http/nginx.cross.conf:/etc/nginx/nginx.conf
+      - cache:/cache
+    ports:
+      - "8082:8082" # nginx gateway endpoint
+    depends_on:
+      - http_gw
+
+volumes:
+  data:
+  cache:

--- a/http/nginx.cross.conf
+++ b/http/nginx.cross.conf
@@ -1,0 +1,29 @@
+events {
+        worker_connections 1024;
+        multi_accept off;
+}
+
+http {
+  proxy_cache_path /cache levels=1:2 keys_zone=neofs_cache:50m max_size=10G inactive=60m use_temp_path=off;
+
+  server {
+    listen [::]:8082 default_server ipv6only=off;
+    server_name nginx_gate;
+
+    location / {
+      rewrite '^(/[0-9a-zA-Z]{43,44}/[0-9a-zA-Z\-]{43,44})$' /get/$1 break;
+      rewrite '^/([0-9a-zA-Z]{43,44})/$'                     /get_by_attribute/$1/FileName/index.html break;
+      rewrite '^/([0-9a-zA-Z]{43,44})/([^/]*)$'              /get_by_attribute/$1/FileName/$2 break;
+      rewrite '^/([0-9a-zA-Z]{43,44})/(.*)$'                 /get_by_attribute/$1/FilePath/$2 break;
+
+      proxy_pass http://http_gw:8081;
+      proxy_http_version 1.1;
+      proxy_intercept_errors on;
+      proxy_buffering on;
+      proxy_cache neofs_cache;
+      proxy_cache_methods GET;
+      proxy_cache_valid 200 15m;
+      proxy_cache_valid 404 0;
+    }
+  }
+}


### PR DESCRIPTION
neofs-aio may be used as a simpler version of [neofs-dev-env](https://github.com/nspcc-dev/neofs-dev-env) for testing and experimenting with NeoFS. Even though NeoFS itself is targeted only for Linux based machines, it is possible to run nodes in macOS and Windows with WSL 2, so wider set of developers can try NeoFS before setting infrastructure.

To support other platforms we need to avoid `network_mode: host` in docker-compose, because host networking driver only works on Linux hosts, and is not supported on Docker Desktop for Mac, Docker Desktop for Windows, or Docker EE for Windows Server. (https://docs.docker.com/network/host/)

`docker-compose.cross.yml` uses docker image host names for networking and avoids `localhost` unlike `docker-compose.yml`.