### PR TITLE
init: always provide default http/rest gw env, fix #56

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,8 @@ COPY ./morph/node-wallet.json /config/node-wallet.json
 COPY ./morph/node-config.yaml /config/node-config.yaml
 COPY ./bin/ /config/bin
 
+COPY ./http/http.env /config/http.env
+COPY ./rest-gw/rest.env /config/rest.env
+RUN sed -ri 's,^([^=]+)=(.*)+$,\1=${\1-\2},' /config/http.env /config/rest.env
+
 ENTRYPOINT ["/config/bin/init-aio.sh"]

--- a/bin/init-aio.sh
+++ b/bin/init-aio.sh
@@ -30,6 +30,11 @@ do
   sleep 5;
 done
 
+set -a
+
+. /config/http.env
+. /config/rest.env
+
 /usr/bin/neofs-http-gw &
 /usr/bin/neofs-rest-gw &
 

--- a/bin/init-aio.sh
+++ b/bin/init-aio.sh
@@ -27,7 +27,7 @@ set -m
 while [[ -z "$(/usr/bin/neofs-cli control healthcheck --endpoint localhost:16513 -c /config/cli-cfg-sn.yaml | grep 'Network status: ONLINE')" ]];
 do
   ./bin/tick.sh
-  sleep 5;
+  sleep 2
 done
 
 set -a


### PR DESCRIPTION
It can be overridden, but the defaults will be taken from the internal .envs. This allows to run the container with all gateways without docker-compose.