### PR TITLE
ir: Set `session_pool_size` equal 50

### DIFF
--- a/ir/config.yaml
+++ b/ir/config.yaml
@@ -22,6 +22,7 @@ fschain:
     rpc:
       listen:
         - 0.0.0.0:30333
+      session_pool_size: 50
     p2p:
       dial_timeout: 3s
       proto_tick_interval: 2s


### PR DESCRIPTION
This value was increased from the default (20) for parallel test runs.