### PR TITLE
config: listen to pprof and metrics globally, not localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,10 @@ services:
       - "16513:16513" # Control service
       - "8090:8090" # REST Gateway endpoint
       - "9000:9000" # S3 Gateway endpoint
+#      - "6661:6661" # NeoFS IR's pprof
+#      - "6662:6662" # NeoFS IR's metrics
+#      - "6663:6663" # NeoFS SN's pprof
+#      - "6664:6664" # NeoFS SN's metrics
 
   nginx_gw:
     image: nginx:stable-alpine

--- a/ir/config.yaml
+++ b/ir/config.yaml
@@ -57,11 +57,11 @@ logger:
 
 pprof:
   enabled: false
-  address: localhost:6661
+  address: :6661
 
 prometheus:
   enabled: false
-  address: localhost:6662
+  address: :6662
 
 control:
   grpc:

--- a/sn/config.yaml
+++ b/sn/config.yaml
@@ -29,11 +29,11 @@ logger:
 
 prometheus:
   enabled: false
-  address: localhost:6664
+  address: :6664
 
 pprof:
   enabled: false
-  address: localhost:6663
+  address: :6663
 
 storage:
   shards:


### PR DESCRIPTION
It cannot be used in this form once needed. Also, add this ports to compose file, they all have different numbers for a reason, let it be simpler to use them.